### PR TITLE
Fixing a problem in payload generation

### DIFF
--- a/TreblleCore/TreblleMiddleware.cs
+++ b/TreblleCore/TreblleMiddleware.cs
@@ -56,13 +56,6 @@ internal class TreblleMiddleware
 
             _stopwatch.Stop();
 
-            if (!httpContext.Response.ContentType.Contains("application/json"))
-            {
-                _logger.LogInformation("Attempted to intercept response but content type was not valid. Treblle only works on JSON APIs.");
-
-                return;
-            }
-
             var payload = await _trebllePayloadFactory.CreateAsync(
                 httpContext,
                 memoryStream,

--- a/TreblleCore/TrebllePayloadFactory.cs
+++ b/TreblleCore/TrebllePayloadFactory.cs
@@ -115,6 +115,7 @@ internal sealed class TrebllePayloadFactory
         {
             if (httpContext.Request.ContentType != null)
             {
+                httpContext.Request.Body.Position = 0;
                 using var requestReader = new StreamReader(httpContext.Request.Body);
                 var bodyData = await requestReader.ReadToEndAsync();
 

--- a/TreblleCore/TreblleService.cs
+++ b/TreblleCore/TreblleService.cs
@@ -1,12 +1,12 @@
-﻿using Newtonsoft.Json;
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Json;
+using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace Treblle.Net.Core;
 
@@ -59,8 +59,8 @@ internal sealed class TreblleService
 
             var maskedJsonPayload = jsonPayload.Mask(SensitiveWords.ToArray(), "*****");
 
-            var httpResponseMessage = await _httpClient.PostAsJsonAsync(string.Empty, maskedJsonPayload);
-
+            using HttpContent content = new StringContent(maskedJsonPayload, Encoding.UTF8, "application/json");
+            var httpResponseMessage = await _httpClient.PostAsync(string.Empty, content);
             return httpResponseMessage;
         }
         catch (Exception ex)


### PR DESCRIPTION
- PostAsJsonAsync was putting the payload into an array, generating an invalid payload. It was changed to PostAsync passing HttpContent. The payload is now valid.
- In the Payload Factory, returning the Body to Position 0 was necessary, as it was reaching the end, making it impossible to recover the values. 
- Removed content-type checking from the response as it did not allow endpoints that did not return a JSON to be sent to Treblle.