### PR TITLE
TreblleMiddleware reusing StopWatch instance, resulting in cumulative request duration times

### DIFF
--- a/TreblleCore/TreblleMiddleware.cs
+++ b/TreblleCore/TreblleMiddleware.cs
@@ -45,7 +45,7 @@ internal class TreblleMiddleware
         {
             httpContext.Request.EnableBuffering();
 
-            var stopwatch = Stopwatch.StartNew();
+            var stopwatch = ValueStopwatch.StartNew();
 
             using var memoryStream = new MemoryStream();
 
@@ -53,12 +53,12 @@ internal class TreblleMiddleware
 
             await _next(httpContext);
 
-            stopwatch.Stop();
+            var elapsed = stopwatch.GetElapsedTime();
 
             var payload = await _trebllePayloadFactory.CreateAsync(
                 httpContext,
                 memoryStream,
-                stopwatch.ElapsedMilliseconds);
+                (long)elapsed.TotalMilliseconds);
 
             memoryStream.Position = 0;
 

--- a/TreblleCore/TreblleMiddleware.cs
+++ b/TreblleCore/TreblleMiddleware.cs
@@ -12,8 +12,7 @@ internal class TreblleMiddleware
     private readonly TreblleService _treblleService;
     private readonly TrebllePayloadFactory _trebllePayloadFactory;
     private readonly ILogger<TreblleMiddleware> _logger;
-    private readonly Stopwatch _stopwatch = new();
-    
+
     public TreblleMiddleware(
         RequestDelegate next,
         TreblleService treblleService,
@@ -46,7 +45,7 @@ internal class TreblleMiddleware
         {
             httpContext.Request.EnableBuffering();
 
-            _stopwatch.Start();
+            var stopwatch = Stopwatch.StartNew();
 
             using var memoryStream = new MemoryStream();
 
@@ -54,12 +53,12 @@ internal class TreblleMiddleware
 
             await _next(httpContext);
 
-            _stopwatch.Stop();
+            stopwatch.Stop();
 
             var payload = await _trebllePayloadFactory.CreateAsync(
                 httpContext,
                 memoryStream,
-                _stopwatch.ElapsedMilliseconds);
+                stopwatch.ElapsedMilliseconds);
 
             memoryStream.Position = 0;
 

--- a/TreblleCore/ValueStopwatch.cs
+++ b/TreblleCore/ValueStopwatch.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this
+// file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+
+namespace Treblle.Net.Core
+{
+    internal struct ValueStopwatch
+    {
+        private static readonly double TimestampToTicks = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+
+        private readonly long _startTimestamp;
+
+        private ValueStopwatch(long startTimestamp)
+        {
+            _startTimestamp = startTimestamp;
+        }
+
+        public bool IsActive => _startTimestamp != 0;
+
+        public static ValueStopwatch StartNew() => new ValueStopwatch(Stopwatch.GetTimestamp());
+
+        public TimeSpan GetElapsedTime()
+        {
+            // Start timestamp can't be zero in an initialized ValueStopwatch. It would have to be
+            // literally the first thing executed when the machine boots to be 0. So it being 0 is a
+            // clear indication of default(ValueStopwatch)
+            if (!IsActive)
+            {
+                throw new InvalidOperationException("An uninitialized, or 'default', ValueStopwatch cannot be used to get elapsed time.");
+            }
+
+            var end = Stopwatch.GetTimestamp();
+
+            var timestampDelta = end - _startTimestamp;
+            var ticks = (long)(TimestampToTicks * timestampDelta);
+            return new TimeSpan(ticks);
+        }
+    }
+}


### PR DESCRIPTION
I noticed that the request times displayed in Treblle were orders of magnitude higher than they should be. Also reported by @Ronny in the Treblle discord channel for the dotnet-core sdk. 

For example a request which took 500ms in Chrome Dev Tools was reporting as 26seconds in Treblle.

Looking at the code for the TreblleMiddleware I can see that there is a private readonly StopWatch being instantiated within the class. However, as Middleware is constructed once per application, it means that this StopWatch is being used for all requests.

`            
           _stopwatch.Start();

            using var memoryStream = new MemoryStream();

            httpContext.Response.Body = memoryStream;

            await _next(httpContext);

            _stopwatch.Stop();
`

Stopping and Starting the StopWatch in this way means that the time is cumulative. The stopwatch is never reset.

The PullRequest has swapped out this private readonly StopWatch with an Microsoft ValueStopwatch struct implementation, which reduces allocations of instances of Stopwatch, and provides a .GetElapsedTime() method.

Note: .NET7 introduced the .GetElapsedTime() method to the standard Stopwatch, but as we're targeting .NET6 then we need to reproduce this mechanism here.

