### PR TITLE
Fix not sending payloads with null properties bug

### DIFF
--- a/TreblleCore/Masking/CreditCardMasker.cs
+++ b/TreblleCore/Masking/CreditCardMasker.cs
@@ -10,6 +10,9 @@ namespace Treblle.Runtime.Masking
 
         public override bool IsPatternMatch(string input)
         {
+            if (input is null)
+                return false;
+
             return Regex.IsMatch(input, _creditCardPattern);
         }
 

--- a/TreblleCore/Masking/DateMasker.cs
+++ b/TreblleCore/Masking/DateMasker.cs
@@ -13,6 +13,9 @@ namespace Treblle.Runtime.Masking
 
         public override bool IsPatternMatch(string input)
         {
+            if (input is null)
+                return false;
+
             return Regex.IsMatch(input, _datePatternSlashes) || Regex.IsMatch(input, _datePatternSlashesYearFirst) ||
                             (Regex.IsMatch(input, _datePatternDashes) || Regex.IsMatch(input, _datePatternDashesYearFirst));
         }

--- a/TreblleCore/Masking/DefaultStringMasker.cs
+++ b/TreblleCore/Masking/DefaultStringMasker.cs
@@ -6,6 +6,9 @@ public class DefaultStringMasker : IStringMasker
 {
     public virtual bool IsPatternMatch(string input)
     {
+        if (input is null)
+            return false;
+
         return false;
     }
 

--- a/TreblleCore/Masking/EmailMasker.cs
+++ b/TreblleCore/Masking/EmailMasker.cs
@@ -9,6 +9,9 @@ public sealed class EmailMasker : DefaultStringMasker ,IStringMasker
 
     public override bool IsPatternMatch(string input)
     {
+        if (input is null)
+            return false;
+
         return Regex.IsMatch(input, _emailPattern);
     }
     string IStringMasker.Mask(string input)

--- a/TreblleCore/Masking/PostalCodeMasker.cs
+++ b/TreblleCore/Masking/PostalCodeMasker.cs
@@ -10,6 +10,9 @@ namespace Treblle.Runtime.Masking
 
         public override bool IsPatternMatch(string input)
         {
+            if (input is null)
+                return false;
+
             return Regex.IsMatch(input, _postalCodePattern);
         }
 

--- a/TreblleCore/Masking/SocialSecurityMasker.cs
+++ b/TreblleCore/Masking/SocialSecurityMasker.cs
@@ -10,6 +10,9 @@ namespace Treblle.Net.Core.Masking
 
         public override bool IsPatternMatch(string input)
         {
+            if (input is null)
+                return false;
+
             return Regex.IsMatch(input, _socialSecurityPattern);
         }
 

--- a/TreblleCore/Treblle.Net.Core.csproj
+++ b/TreblleCore/Treblle.Net.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Authors>Treblle</Authors>
-    <Version>1.3.2</Version>
+    <Version>1.3.3</Version>
     <PackageId>Treblle.Net.Core</PackageId>
     <Product>Treblle .NET Core</Product>
     <Description>Treblle makes it super easy to understand what's going on with your APIs and the apps that use them.</Description>

--- a/TreblleCore/Treblle.Net.Core.nuspec
+++ b/TreblleCore/Treblle.Net.Core.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Treblle.Net.Core</id>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     <authors>Treblle</authors>
     <owners>Treblle</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
Adding null check to IsPatternMatch method, it is now need because of the json serialization change