### PR TITLE
Custom Ingress Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Treblle offers several configuration options:
 | `ExcludedPaths` | `null` | Exclude specific paths or endpoints from Treblle |
 | `DebugMode` | `false` | Enable detailed logging for troubleshooting |
 | `DisableMasking` | `false` | Disable data masking if not needed |
+| `CustomIngressEndpoint` | `null` | Custom endpoint URL for sending telemetry data |
 
 **Example with all options:**
 ```csharp
@@ -318,6 +319,43 @@ All debug logs are prefixed with "[TREBLLE]:" and use `LogDebug` level, making t
 ```
 
 **Note:** Debug mode should typically only be enabled in development or staging environments as it increases log verbosity.
+
+### Custom Ingress Endpoint
+
+By default, Treblle sends telemetry data to its global endpoints. If you need to route data through a specific regional endpoint or a custom ingress URL, you can configure a custom ingress endpoint.
+
+**Option A: Environment Variable**
+```bash
+export TREBLLE_CUSTOM_INGRESS_ENDPOINT=https://ingress-eu.treblle.com
+```
+
+**Option B: appsettings.json**
+```json
+{
+  "Treblle": {
+    "SdkToken": "your_sdk_token",
+    "ApiKey": "your_api_key",
+    "CustomIngressEndpoint": "https://ingress-eu.treblle.com"
+  }
+}
+```
+
+**Option C: Programmatic Configuration**
+```csharp
+// Import the Treblle SDK
+using Treblle.Net.Core;
+
+builder.Services.AddTreblle(options =>
+{
+    options.CustomIngressEndpoint = "https://ingress-eu.treblle.com";
+});
+
+// Build your application
+var app = builder.Build();
+
+// Enable the Treblle Middleware
+app.UseTreblle();
+```
 
 ### Excluding endpoints or paths
 

--- a/TreblleCore/ServiceCollectionExtensions.cs
+++ b/TreblleCore/ServiceCollectionExtensions.cs
@@ -110,12 +110,22 @@ public static class ServiceCollectionExtensions
                 var (sdkToken, apiKey) = GetTreblleCredentials(configuration);
                 options.SdkToken = sdkToken;
                 options.ApiKey = apiKey;
+                options.CustomIngressEndpoint = GetCustomIngressEndpoint(configuration);
             });
 
         if (configureOptions != null)
         {
             services.PostConfigure<TreblleOptions>(configureOptions);
         }
+
+        // Validate and normalize custom ingress endpoint if provided via options action
+        services.PostConfigure<TreblleOptions>(options =>
+        {
+            if (!string.IsNullOrWhiteSpace(options.CustomIngressEndpoint))
+            {
+                options.CustomIngressEndpoint = ValidateAndNormalizeIngressEndpoint(options.CustomIngressEndpoint);
+            }
+        });
 
         // Register services without credential validation since they're handled by options
         services.TryAddTransient<TreblleService>(serviceProvider =>
@@ -144,7 +154,7 @@ public static class ServiceCollectionExtensions
                 }
             }
 
-            return new(httpClientFactory, maskingMap, logger, serviceProvider, options.DisableMasking, options.DebugMode);
+            return new(httpClientFactory, maskingMap, logger, serviceProvider, options.DisableMasking, options.DebugMode, options.CustomIngressEndpoint);
         });
 
         services.TryAddSingleton<TrebllePayloadFactory>();
@@ -254,9 +264,9 @@ public static class ServiceCollectionExtensions
                 }
             }
 
-            return new(httpClientFactory, maskingMap, logger, serviceProvider, options.DisableMasking, options.DebugMode);
+            return new(httpClientFactory, maskingMap, logger, serviceProvider, options.DisableMasking, options.DebugMode, options.CustomIngressEndpoint);
         });
-        
+
         services.TryAddSingleton<TrebllePayloadFactory>();
         services.Configure<TreblleOptions>(o =>
         {
@@ -268,6 +278,12 @@ public static class ServiceCollectionExtensions
 
             // Apply additional configuration if provided
             configureOptions?.Invoke(o);
+
+            // Validate and normalize custom ingress endpoint if provided
+            if (!string.IsNullOrWhiteSpace(o.CustomIngressEndpoint))
+            {
+                o.CustomIngressEndpoint = ValidateAndNormalizeIngressEndpoint(o.CustomIngressEndpoint);
+            }
         });
 
         services.AddHttpClient("Treblle", (serviceProvider, httpClient) =>
@@ -337,6 +353,54 @@ public static class ServiceCollectionExtensions
         }
 
         return (sdkToken, apiKey);
+    }
+
+    /// <summary>
+    /// Gets the custom ingress endpoint from environment variable or configuration.
+    /// Returns null if not configured.
+    /// </summary>
+    private static string? GetCustomIngressEndpoint(IConfiguration configuration)
+    {
+        var endpoint =
+            // Environment variable has highest precedence
+            Environment.GetEnvironmentVariable("TREBLLE_CUSTOM_INGRESS_ENDPOINT") ??
+            // Configuration from appsettings.json
+            configuration["Treblle:CustomIngressEndpoint"];
+
+        if (string.IsNullOrWhiteSpace(endpoint))
+        {
+            return null;
+        }
+
+        return ValidateAndNormalizeIngressEndpoint(endpoint);
+    }
+
+    /// <summary>
+    /// Validates and normalizes a custom ingress endpoint URL.
+    /// </summary>
+    /// <param name="endpoint">The endpoint URL to validate</param>
+    /// <returns>The normalized endpoint URL (without trailing slash)</returns>
+    /// <exception cref="ArgumentException">Thrown when the URL is invalid</exception>
+    private static string ValidateAndNormalizeIngressEndpoint(string endpoint)
+    {
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var uri))
+        {
+            throw new ArgumentException(
+                $"Invalid CustomIngressEndpoint URL: '{endpoint}'. Must be a valid absolute URL.",
+                nameof(endpoint));
+        }
+
+        if (uri.Scheme != Uri.UriSchemeHttps)
+        {
+            throw new ArgumentException(
+                $"Invalid CustomIngressEndpoint URL: '{endpoint}'. Must use HTTPS scheme.",
+                nameof(endpoint));
+        }
+
+        // Normalize: remove trailing slash
+        var normalizedUrl = uri.GetLeftPart(UriPartial.Authority) + uri.AbsolutePath.TrimEnd('/');
+
+        return normalizedUrl;
     }
 
 }

--- a/TreblleCore/ThrottleState.cs
+++ b/TreblleCore/ThrottleState.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Threading;
+
+namespace Treblle.Net.Core;
+
+/// <summary>
+/// Lock-free state machine for handling rate limiting (HTTP 429) responses.
+/// Uses Interlocked operations for thread safety with minimal memory footprint.
+/// </summary>
+internal sealed class ThrottleState
+{
+    private const int StateNormal = 0;
+    private const int StateBackingOff = 1;
+    private const int StateProbing = 2;
+
+    private const long InitialBackoffMs = 1000;      // 1 second
+    private const long MaxBackoffMs = 60000;         // 60 seconds
+    private const double BackoffMultiplier = 2.0;
+    private const double JitterFactor = 0.2;         // 20% jitter
+    private const int SuccessesRequiredForRecovery = 2;
+
+    private static readonly Random JitterRandom = new();
+
+    // State fields - using long for Interlocked compatibility
+    private long _state = StateNormal;
+    private long _backoffUntilTicks;
+    private long _currentBackoffMs = InitialBackoffMs;
+    private long _consecutiveSuccesses;
+
+    /// <summary>
+    /// Checks if payloads should be throttled (dropped) based on current state.
+    /// This is an O(1) operation with no allocations.
+    /// </summary>
+    /// <returns>True if payload should be dropped, false if it should be sent.</returns>
+    public bool ShouldThrottle()
+    {
+        var state = Interlocked.Read(ref _state);
+
+        if (state == StateNormal)
+        {
+            return false;
+        }
+
+        if (state == StateBackingOff)
+        {
+            var backoffUntil = Interlocked.Read(ref _backoffUntilTicks);
+            var now = DateTime.UtcNow.Ticks;
+
+            if (now >= backoffUntil)
+            {
+                // Backoff expired, transition to probing
+                Interlocked.CompareExchange(ref _state, StateProbing, StateBackingOff);
+                return false; // Allow this request through as probe
+            }
+
+            return true; // Still in backoff, throttle
+        }
+
+        // StateProbing - allow limited traffic through
+        return false;
+    }
+
+    /// <summary>
+    /// Records a 429 (Too Many Requests) response from the API.
+    /// </summary>
+    /// <param name="retryAfterSeconds">Optional Retry-After header value in seconds.</param>
+    public void RecordThrottleResponse(int? retryAfterSeconds)
+    {
+        long backoffMs;
+
+        if (retryAfterSeconds.HasValue && retryAfterSeconds.Value > 0)
+        {
+            // Use server-specified retry-after duration
+            backoffMs = Math.Min(retryAfterSeconds.Value * 1000L, MaxBackoffMs);
+        }
+        else
+        {
+            // Use exponential backoff with jitter
+            var currentBackoff = Interlocked.Read(ref _currentBackoffMs);
+            var jitter = 1.0 + (JitterRandom.NextDouble() * JitterFactor * 2 - JitterFactor);
+            backoffMs = (long)(currentBackoff * jitter);
+
+            // Double the backoff for next time (up to max)
+            var nextBackoff = Math.Min((long)(currentBackoff * BackoffMultiplier), MaxBackoffMs);
+            Interlocked.Exchange(ref _currentBackoffMs, nextBackoff);
+        }
+
+        var backoffUntil = DateTime.UtcNow.AddMilliseconds(backoffMs).Ticks;
+        Interlocked.Exchange(ref _backoffUntilTicks, backoffUntil);
+        Interlocked.Exchange(ref _consecutiveSuccesses, 0);
+        Interlocked.Exchange(ref _state, StateBackingOff);
+    }
+
+    /// <summary>
+    /// Records a successful API response. Multiple consecutive successes
+    /// during probing state will transition back to normal.
+    /// </summary>
+    public void RecordSuccess()
+    {
+        var state = Interlocked.Read(ref _state);
+
+        if (state == StateNormal)
+        {
+            return; // Already normal, nothing to do
+        }
+
+        if (state == StateProbing)
+        {
+            var successes = Interlocked.Increment(ref _consecutiveSuccesses);
+
+            if (successes >= SuccessesRequiredForRecovery)
+            {
+                // Recovered - reset to normal state
+                Interlocked.Exchange(ref _currentBackoffMs, InitialBackoffMs);
+                Interlocked.Exchange(ref _consecutiveSuccesses, 0);
+                Interlocked.Exchange(ref _state, StateNormal);
+            }
+        }
+    }
+}

--- a/TreblleCore/Treblle.Net.Core.csproj
+++ b/TreblleCore/Treblle.Net.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Authors>Treblle</Authors>
-    <Version>2.0.5</Version>
+    <Version>2.0.6</Version>
     <PackageId>Treblle.Net.Core</PackageId>
     <Product>Treblle .NET Core</Product>
     <Description>Treblle makes it super easy to understand what's going on with your APIs and the apps that use them.</Description>

--- a/TreblleCore/TreblleMiddleware.cs
+++ b/TreblleCore/TreblleMiddleware.cs
@@ -55,6 +55,16 @@ internal class TreblleMiddleware : IDisposable
             {
                 while (_channel.Reader.TryRead(out var payload))
                 {
+                    // Check if we're being rate limited - drop payload silently if so
+                    if (_treblleService.ShouldThrottle())
+                    {
+                        if (_options.DebugMode)
+                        {
+                            _logger.LogDebug("[TREBLLE]: Payload dropped - rate limited");
+                        }
+                        continue; // Drop payload and process next
+                    }
+
                     try
                     {
                         await _treblleService.SendPayloadAsync(payload);

--- a/TreblleCore/TreblleOptions.cs
+++ b/TreblleCore/TreblleOptions.cs
@@ -35,4 +35,13 @@ public sealed class TreblleOptions
     /// Case-insensitive matching is used.
     /// </summary>
     public string[]? ExcludedPaths { get; set; } = null;
+
+    /// <summary>
+    /// Custom ingress endpoint URL for sending telemetry data.
+    /// When set, this endpoint will be used instead of the default Treblle endpoints.
+    /// Must be a valid HTTPS URL. Trailing slashes will be removed automatically.
+    /// Example: "https://ingress-eu.treblle.com"
+    /// Can also be set via TREBLLE_CUSTOM_INGRESS_ENDPOINT environment variable.
+    /// </summary>
+    public string? CustomIngressEndpoint { get; set; }
 }

--- a/TreblleCore/TreblleService.cs
+++ b/TreblleCore/TreblleService.cs
@@ -39,6 +39,7 @@ internal sealed class TreblleService
     private readonly IServiceProvider _serviceProvider;
     private readonly bool _disableMasking;
     private readonly bool _debugMode;
+    private readonly string? _customIngressEndpoint;
 
     public TreblleService(
         IHttpClientFactory httpClientFactory,
@@ -46,7 +47,8 @@ internal sealed class TreblleService
         ILogger<TreblleService> logger,
         IServiceProvider serviceProvider,
         bool disableMasking = false,
-        bool debugMode = false)
+        bool debugMode = false,
+        string? customIngressEndpoint = null)
     {
         _httpClient = httpClientFactory.CreateClient("Treblle");
         _logger = logger;
@@ -54,6 +56,7 @@ internal sealed class TreblleService
         _serviceProvider = serviceProvider;
         _disableMasking = disableMasking;
         _debugMode = debugMode;
+        _customIngressEndpoint = customIngressEndpoint;
     }
 
     public async Task<HttpResponseMessage?> SendPayloadAsync(TrebllePayload payload)
@@ -106,7 +109,9 @@ internal sealed class TreblleService
                 ? jsonPayload 
                 : jsonPayload.Mask(_maskingMap, _serviceProvider, _logger);
 
-            var randomEndpoint = TreblleEndpoints[Random.Next(TreblleEndpoints.Length)];
+            var endpoint = !string.IsNullOrWhiteSpace(_customIngressEndpoint)
+                ? _customIngressEndpoint
+                : TreblleEndpoints[Random.Next(TreblleEndpoints.Length)];
             
             var jsonBytes = Encoding.UTF8.GetBytes(finalJsonPayload ?? string.Empty);
             var compressedBytes = CompressData(jsonBytes);
@@ -120,7 +125,7 @@ internal sealed class TreblleService
                 content.Headers.ContentEncoding.Add("gzip");
             }
             
-            using var httpResponseMessage = await _httpClient.PostAsync(randomEndpoint, content);
+            using var httpResponseMessage = await _httpClient.PostAsync(endpoint, content);
             return httpResponseMessage;
         }
         catch (Exception ex)

--- a/TreblleCore/TreblleService.cs
+++ b/TreblleCore/TreblleService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -40,6 +41,7 @@ internal sealed class TreblleService
     private readonly bool _disableMasking;
     private readonly bool _debugMode;
     private readonly string? _customIngressEndpoint;
+    private readonly ThrottleState _throttleState = new();
 
     public TreblleService(
         IHttpClientFactory httpClientFactory,
@@ -58,6 +60,11 @@ internal sealed class TreblleService
         _debugMode = debugMode;
         _customIngressEndpoint = customIngressEndpoint;
     }
+
+    /// <summary>
+    /// Checks if payloads should be throttled due to rate limiting.
+    /// </summary>
+    public bool ShouldThrottle() => _throttleState.ShouldThrottle();
 
     public async Task<HttpResponseMessage?> SendPayloadAsync(TrebllePayload payload)
     {
@@ -126,6 +133,26 @@ internal sealed class TreblleService
             }
             
             using var httpResponseMessage = await _httpClient.PostAsync(endpoint, content);
+
+            if (httpResponseMessage.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                var retryAfter = ParseRetryAfter(httpResponseMessage);
+                _throttleState.RecordThrottleResponse(retryAfter);
+
+                if (_debugMode)
+                {
+                    _logger.LogDebug("[TREBLLE]: Rate limited (429) - backing off for {Seconds}s",
+                        retryAfter ?? 0);
+                }
+
+                return httpResponseMessage;
+            }
+
+            if (httpResponseMessage.IsSuccessStatusCode)
+            {
+                _throttleState.RecordSuccess();
+            }
+
             return httpResponseMessage;
         }
         catch (Exception ex)
@@ -137,6 +164,21 @@ internal sealed class TreblleService
 
             return null;
         }
+    }
+
+    private static int? ParseRetryAfter(HttpResponseMessage response)
+    {
+        if (response.Headers.TryGetValues("Retry-After", out var values))
+        {
+            foreach (var value in values)
+            {
+                if (int.TryParse(value, out var seconds))
+                {
+                    return seconds;
+                }
+            }
+        }
+        return null;
     }
 
     private static byte[] CompressData(byte[] data)


### PR DESCRIPTION
This release brings a new configuration option that allows customers to send data to a custom Treblle ingress endpoint. We also added networking improvements by introducing a circuit breaker mechanism that backs-off in case a any 5xx or 4xx issues on the ingress endpoint. 