### PR TITLE
feat: per-endpoint or controller API key override via [Treblle] attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,8 @@ public IActionResult GetOrders() => Ok();
 
 The attribute is not required for standard tracking — all endpoints are monitored automatically. Use it only when you need to route specific controllers or actions to a different Treblle project.
 
+Note that app.UseTreblle() has to come after app.UseRouting() for this to work.
+
 ### Excluding endpoints or paths
 
 By default, Treblle now automatically tracks **all endpoints** without requiring manual `[Treblle]` attributes. You can exclude specific paths using the `ExcludedPaths` configuration:

--- a/README.md
+++ b/README.md
@@ -357,6 +357,25 @@ var app = builder.Build();
 app.UseTreblle();
 ```
 
+### Per-Endpoint API Key Override
+
+If you need a specific controller or endpoint to report to a different Treblle project, pass an API key directly to the `[Treblle]` attribute:
+
+```csharp
+// Override for an entire controller
+[Treblle("your_per_endpoint_api_key")]
+public class OrdersController : ControllerBase
+{
+    public IActionResult GetOrders() => Ok();
+}
+
+// Or override for a single action
+[Treblle("your_per_endpoint_api_key")]
+public IActionResult GetOrders() => Ok();
+```
+
+The attribute is not required for standard tracking — all endpoints are monitored automatically. Use it only when you need to route specific controllers or actions to a different Treblle project.
+
 ### Excluding endpoints or paths
 
 By default, Treblle now automatically tracks **all endpoints** without requiring manual `[Treblle]` attributes. You can exclude specific paths using the `ExcludedPaths` configuration:

--- a/TreblleCore/TreblleAttribute.cs
+++ b/TreblleCore/TreblleAttribute.cs
@@ -4,4 +4,10 @@ namespace Treblle.Net.Core;
 
 public sealed class TreblleAttribute : Attribute
 {
+    public string? ApiKey { get; set; }
+
+    public TreblleAttribute(string? apiKey = null)
+    {
+        ApiKey = apiKey;
+    }
 }

--- a/TreblleCore/TreblleMiddleware.cs
+++ b/TreblleCore/TreblleMiddleware.cs
@@ -183,7 +183,7 @@ internal class TreblleMiddleware : IDisposable
         
         if (shouldTrack)
         {
-            await HandleRequestWithTreblleAsync(httpContext);
+            await HandleRequestWithTreblleAsync(httpContext, treblleAttribute);
         }
         else
         {
@@ -191,7 +191,7 @@ internal class TreblleMiddleware : IDisposable
         }
     }
 
-    private async Task HandleRequestWithTreblleAsync(HttpContext httpContext)
+    private async Task HandleRequestWithTreblleAsync(HttpContext httpContext, TreblleAttribute? treblleAttribute)
     {
         var originalResponseBody = httpContext.Response.Body;
         var stopwatch = Stopwatch.StartNew();
@@ -265,7 +265,8 @@ internal class TreblleMiddleware : IDisposable
                         var payload = await _trebllePayloadFactory.CreateAsync(
                             httpContext,
                             memoryStream,
-                            elapsedMiliseconds);
+                            elapsedMiliseconds,
+                            treblleAttribute: treblleAttribute);
 
                         _channel.Writer.TryWrite(payload);
                         

--- a/TreblleCore/TrebllePayloadFactory.cs
+++ b/TreblleCore/TrebllePayloadFactory.cs
@@ -49,14 +49,17 @@ internal sealed class TrebllePayloadFactory
         HttpContext httpContext,
         MemoryStream? response,
         long elapsedMilliseconds,
-        Exception? exception = null)
+        Exception? exception = null,
+        TreblleAttribute? treblleAttribute = null)
     {
+        string? apiKey = treblleAttribute?.ApiKey;
+
         var payload = new TrebllePayload
         {
             Sdk = "net-core",
             Version = TreblleConstants.PayloadVersion,
             // Map new properties to legacy payload field names for backward compatibility
-            ProjectId = GetEffectiveApiKey(), // ApiKey from config -> project_id in payload
+            ProjectId = apiKey ?? GetEffectiveApiKey(), // ApiKey from config -> project_id in payload
             ApiKey = GetEffectiveSdkToken(),  // SdkToken from config -> api_key in payload
         };
 


### PR DESCRIPTION
- Added optional ApiKey parameter to [Treblle] attribute to override the globally configured API key per controller or action
- Falls back to global config when no key is provided, fully backward compatible
- [Treblle("custom_key")] sends custom_key as the api key in the payload
- [Treblle] without a key uses the global API key
- No attribute continues to work as before