### PR TITLE
fix: handle XML in request and response body

### DIFF
--- a/TreblleCore/Treblle.Net.Core.csproj
+++ b/TreblleCore/Treblle.Net.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Authors>Treblle</Authors>
-    <Version>2.0.6</Version>
+    <Version>2.0.7</Version>
     <PackageId>Treblle.Net.Core</PackageId>
     <Product>Treblle .NET Core</Product>
     <Description>Treblle makes it super easy to understand what's going on with your APIs and the apps that use them.</Description>

--- a/TreblleCore/TreblleJsonContext.cs
+++ b/TreblleCore/TreblleJsonContext.cs
@@ -11,6 +11,7 @@ namespace Treblle.Net.Core;
 [JsonSerializable(typeof(TrebllePayload))]
 [JsonSerializable(typeof(JsonElement))]
 [JsonSerializable(typeof(object))] // For dynamic request/response bodies
+[JsonSerializable(typeof(List<object>))] 
 [JsonSerializable(typeof(string))] // For dictionary values
 [JsonSerializable(typeof(Dictionary<string, object>))] // For headers
 [JsonSerializable(typeof(Dictionary<string, string>))] // For form data and masking config

--- a/TreblleCore/TrebllePayloadFactory.cs
+++ b/TreblleCore/TrebllePayloadFactory.cs
@@ -374,7 +374,6 @@ internal sealed class TrebllePayloadFactory
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine(e.Message);
                     if (_treblleOptions.DebugMode)
                     {
                         _logger.LogDebug(e, "Treblle Debug: Error occurred while reading XML response content");

--- a/TreblleCore/TrebllePayloadFactory.cs
+++ b/TreblleCore/TrebllePayloadFactory.cs
@@ -300,60 +300,84 @@ internal sealed class TrebllePayloadFactory
     {
         if (response is not null && httpContext.Response?.ContentType is not null)
         {
-            string? contentType = httpContext.Response?.ContentType;
-            if (contentType?.Contains(MediaTypeNames.Application.Json, StringComparison.OrdinalIgnoreCase) == true
-                || contentType?.Contains("application/problem+json", StringComparison.OrdinalIgnoreCase) == true)
+            string contentType = httpContext.Response.ContentType;
+
+            // Align with total payload limit of 5MB
+            const long maxResponseSize = 5 * 1024 * 1024; // 5MB
+            var responseLength = httpContext.Response.ContentLength ?? response.Length;
+            
+            if (responseLength > maxResponseSize)
             {
-                // Align with total payload limit of 5MB
-                const long maxResponseSize = 5 * 1024 * 1024; // 5MB
-                var responseLength = httpContext.Response?.ContentLength ?? response.Length;
-                
-                if (responseLength > maxResponseSize)
+                payload.Data.Response.Body = new Dictionary<string, object?>
                 {
-                    payload.Data.Response.Body = new Dictionary<string, object?>
+                    ["__message"] = "Response data was larger than 5MB",
+                    ["__size"] = responseLength,
+                    ["__type"] = "large_response"
+                };
+                payload.Data.Response.Size = responseLength;
+            }
+            else if (contentType.Contains(MediaTypeNames.Application.Json, StringComparison.OrdinalIgnoreCase) == true
+                || contentType.Contains("application/problem+json", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                response.Position = 0;
+                try
+                {
+                    using var responseReader = new StreamReader(response, leaveOpen: true);
+                    var responseContent = await responseReader.ReadToEndAsync();
+
+                    if (string.IsNullOrWhiteSpace(responseContent))
                     {
-                        ["__message"] = "Response data was larger than 5MB",
-                        ["__size"] = responseLength,
-                        ["__type"] = "large_response"
-                    };
-                    payload.Data.Response.Size = responseLength;
+                        // Empty response body is valid for responses like 204 No Content
+                        payload.Data.Response.Body = null;
+                    }
+                    else if (IsValidJson(responseContent))
+                    {
+                        payload.Data.Response.Body = JsonSerializer.Deserialize<JsonElement>(responseContent, TreblleJsonContext.Default.JsonElement);
+                    }
+                    else
+                    {
+                        if (_treblleOptions.DebugMode)
+                        {
+                            _logger.LogDebug("Treblle Debug: Invalid JSON detected in response body");
+                        }
+                    }
+                    payload.Data.Response.Size = response.Length;
                 }
-                else
+                catch (Exception e)
                 {
-                    response.Position = 0;
-
+                    if (_treblleOptions.DebugMode)
                     {
-                        try
-                        {
-                            using var responseReader = new StreamReader(response, leaveOpen: true);
-                            var responseContent = await responseReader.ReadToEndAsync();
+                        _logger.LogDebug(e, "Treblle Debug: Error occurred while reading response content");
+                    }
 
-                            if (string.IsNullOrWhiteSpace(responseContent))
-                            {
-                                // Empty response body is valid for responses like 204 No Content
-                                payload.Data.Response.Body = null;
-                            }
-                            else if (IsValidJson(responseContent))
-                            {
-                                payload.Data.Response.Body = JsonSerializer.Deserialize<JsonElement>(responseContent, TreblleJsonContext.Default.JsonElement);
-                            }
-                            else
-                            {
-                                if (_treblleOptions.DebugMode)
-                                {
-                                    _logger.LogDebug("Treblle Debug: Invalid JSON detected in response body");
-                                }
-                            }
-                            payload.Data.Response.Size = response.Length;
-                        }
-                        catch (Exception e)
-                        {
-                            if (_treblleOptions.DebugMode)
-                            {
-                                _logger.LogDebug(e, "Treblle Debug: Error occurred while reading response content");
-                            }
-
-                        }
+                }
+            }
+            else if (contentType.Contains("application/xml", StringComparison.OrdinalIgnoreCase)
+                || contentType.Contains("text/xml", StringComparison.OrdinalIgnoreCase))
+            {
+                response.Position = 0;
+                try
+                {
+                    using var responseReader = new StreamReader(response, leaveOpen: true);
+                    var responseContent = await responseReader.ReadToEndAsync();
+                    if (string.IsNullOrWhiteSpace(responseContent))
+                    {
+                        payload.Data.Response.Body = null;
+                    }
+                    else
+                    {
+                        var doc = XDocument.Parse(responseContent);
+                        var jsonText = JsonSerializer.Serialize(ConvertXDocumentToObject(doc), TreblleJsonContext.Default.Object);
+                        payload.Data.Response.Body = JsonSerializer.Deserialize<JsonElement>(jsonText, TreblleJsonContext.Default.JsonElement);
+                    }
+                    payload.Data.Response.Size = response.Length;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e.Message);
+                    if (_treblleOptions.DebugMode)
+                    {
+                        _logger.LogDebug(e, "Treblle Debug: Error occurred while reading XML response content");
                     }
                 }
             }
@@ -548,6 +572,7 @@ internal sealed class TrebllePayloadFactory
         
         foreach (var attr in element.Attributes())
         {
+            if (attr.IsNamespaceDeclaration) continue;
             result[$"@{attr.Name.LocalName}"] = attr.Value;
         }
         

--- a/TreblleCore/TrebllePayloadFactory.cs
+++ b/TreblleCore/TrebllePayloadFactory.cs
@@ -253,11 +253,22 @@ internal sealed class TrebllePayloadFactory
                     {
                         payload.Data.Request.Body = bodyData;
                     }
-                    else if (contentType.Contains("application/xml", StringComparison.OrdinalIgnoreCase))
+                    else if (contentType.Contains("application/xml", StringComparison.OrdinalIgnoreCase)
+                        || contentType.Contains("text/xml", StringComparison.OrdinalIgnoreCase))
                     {
-                        var doc = XDocument.Parse(bodyData);
-                        var jsonText = JsonSerializer.Serialize(ConvertXDocumentToObject(doc), TreblleJsonContext.Default.Object);
-                        payload.Data.Request.Body = JsonSerializer.Deserialize<JsonElement>(jsonText, TreblleJsonContext.Default.JsonElement);
+                        try
+                        {
+                            var doc = XDocument.Parse(bodyData);
+                            var jsonText = JsonSerializer.Serialize(ConvertXDocumentToObject(doc), TreblleJsonContext.Default.Object);
+                            payload.Data.Request.Body = JsonSerializer.Deserialize<JsonElement>(jsonText, TreblleJsonContext.Default.JsonElement);
+                        }
+                        catch (Exception)
+                        {
+                            if (_treblleOptions.DebugMode)
+                            {
+                                _logger.LogDebug("[TREBLLE]: Skipping request body - XML contains invalid characters");
+                            }
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
Previously, XDocument.Parse would throw on malformed or namespace-heavy XML, crashing the middleware's payload building. This wraps XML conversion in try/catch for both request and response bodies, adds support for text/xml alongside application/xml, skips namespace declaration attributes during conversion, and extends XML-to-JSON conversion to response bodies (previously only request bodies were converted).