### PR TITLE
Avoid duplicate x-api-key headers when calling AddTreblle() multiple times

### DIFF
--- a/TreblleCore/ServiceCollectionExtensions.cs
+++ b/TreblleCore/ServiceCollectionExtensions.cs
@@ -162,6 +162,7 @@ public static class ServiceCollectionExtensions
         services.AddHttpClient("Treblle", (serviceProvider, httpClient) =>
         {
             var options = serviceProvider.GetRequiredService<IOptions<TreblleOptions>>().Value;
+            httpClient.DefaultRequestHeaders.Remove("x-api-key");
             httpClient.DefaultRequestHeaders.Add("x-api-key", options.SdkToken);
             httpClient.Timeout = TimeSpan.FromSeconds(10);
         })
@@ -289,6 +290,7 @@ public static class ServiceCollectionExtensions
         services.AddHttpClient("Treblle", (serviceProvider, httpClient) =>
         {
             var options = serviceProvider.GetRequiredService<IOptions<TreblleOptions>>().Value;
+            httpClient.DefaultRequestHeaders.Remove("x-api-key");
             httpClient.DefaultRequestHeaders.Add("x-api-key", options.SdkToken);
             httpClient.Timeout = TimeSpan.FromSeconds(10);
         })


### PR DESCRIPTION
Makes sure only one x-api-key is set by clearing the header before re-adding it