### PR TITLE
Fix array field masking and custom options not applied in auto-config…

### DIFF
--- a/TreblleCore/Masking/JsonMasker.cs
+++ b/TreblleCore/Masking/JsonMasker.cs
@@ -45,9 +45,26 @@ public static class JsonMasker
             {
                 var currentPath = string.Join(".", path.Concat(new[] { property.Key }));
 
-                if (property.Value is JsonObject || property.Value is JsonArray)
+                if (property.Value is JsonObject)
                 {
                     MaskFieldsFromJsonNode(property.Value, maskingMap, path.Concat(new[] { property.Key }).ToList(), serviceProvider, logger);
+                }
+                else if (property.Value is JsonArray childArray)
+                {
+                    if (maskingMap.Keys.Any(key => ShouldMask(key, currentPath)))
+                    {
+                        var maskerName = maskingMap.First(m => ShouldMask(m.Key, currentPath)).Value;
+                        var maskerFactory = serviceProvider.GetRequiredService<MaskerFactory>();
+                        var masker = maskerFactory.GetMasker(maskerName);
+                        for (int i = 0; i < childArray.Count; i++)
+                        {
+                            childArray[i] = JsonValue.Create(masker.Mask(childArray[i]?.ToString() ?? string.Empty));
+                        }
+                    }
+                    else
+                    {
+                        MaskFieldsFromJsonNode(property.Value, maskingMap, path.Concat(new[] { property.Key }).ToList(), serviceProvider, logger);
+                    }
                 }
                 else
                 {

--- a/TreblleCore/ServiceCollectionExtensions.cs
+++ b/TreblleCore/ServiceCollectionExtensions.cs
@@ -148,7 +148,19 @@ public static class ServiceCollectionExtensions
             }
             else
             {
-                if (options.DebugMode)
+                if (options.FieldsToMaskPairedWithMaskers is not null)
+                {
+                    foreach (var kv in options.FieldsToMaskPairedWithMaskers)
+                    {
+                        maskingMap[kv.Key] = kv.Value;
+                    }
+
+                    if (options.DebugMode)
+                    {
+                        logger.LogDebug("[TREBLLE]: Using custom masking configuration with {Count} custom rules", options.FieldsToMaskPairedWithMaskers.Count);
+                    }
+                }
+                else if (options.DebugMode)
                 {
                     logger.LogDebug("[TREBLLE]: Using default sensitive words for masking");
                 }

--- a/TreblleCore/Treblle.Net.Core.csproj
+++ b/TreblleCore/Treblle.Net.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Authors>Treblle</Authors>
-    <Version>2.0.8</Version>
+    <Version>2.0.9</Version>
     <PackageId>Treblle.Net.Core</PackageId>
     <Product>Treblle .NET Core</Product>
     <Description>Treblle makes it super easy to understand what's going on with your APIs and the apps that use them.</Description>


### PR DESCRIPTION
### 1. Array fields not masked (`JsonMasker`)

When a masked field contained an array of strings (e.g. `recovery_codes: ["abc", "def"]`), `JsonMasker` would recurse into the array but do nothing with the string elements.

**Fix:** When a `JsonArray` property matches a masking key, each element is masked individually.

### 2. Custom masking fields ignored when using `AddTreblle(Action<TreblleOptions>)`

`AddTreblleWithAutoConfiguration` never read `options.FieldsToMaskPairedWithMaskers`, so any fields configured via the options action were silently ignored.

**Fix:** Merge `FieldsToMaskPairedWithMaskers` into the masking map inside the auto-configuration path, consistent with the other overloads.