### PR TITLE
fix: preserve actual response status code from custom exception handlers

### DIFF
--- a/TreblleCore/Treblle.Net.Core.csproj
+++ b/TreblleCore/Treblle.Net.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Authors>Treblle</Authors>
-    <Version>2.0.10</Version>
+    <Version>2.0.11</Version>
     <PackageId>Treblle.Net.Core</PackageId>
     <Product>Treblle .NET Core</Product>
     <Description>Treblle makes it super easy to understand what's going on with your APIs and the apps that use them.</Description>

--- a/TreblleCore/TrebllePayloadFactory.cs
+++ b/TreblleCore/TrebllePayloadFactory.cs
@@ -449,8 +449,6 @@ internal sealed class TrebllePayloadFactory
         }
 
         payload.Data.Errors.Add(error);
-
-        payload.Data.Response.Code = StatusCodes.Status500InternalServerError;
     }
 
 


### PR DESCRIPTION
  - Removes the line that unconditionally set response.code = 500 whenever an error was appended to the Treblle payload
  - When a custom exception handler returns a non-500 status code (e.g. 422, 409), that code is now correctly reflected in the Treblle payload instead of being overwritten