### PR TITLE
SQL Query Capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,41 @@ app.UseTreblle();
 
 **Performance Impact:** Disabling masking can reduce memory usage by up to 70% for large payloads, as it skips JSON parsing, object tree creation, and field processing operations. This is particularly beneficial for APIs handling large response bodies or high request volumes.
 
+## SQL Query Capture
+
+The SDK automatically captures SQL queries executed during each API request and includes them in the telemetry payload sent to Treblle. This works out of the box with no configuration required.
+
+### How It Works
+
+Treblle listens to [EF Core's diagnostic events](https://learn.microsoft.com/en-us/ef/core/logging-events-diagnostics/diagnostic-listeners) at the application level. When EF Core executes a database command, the SDK captures the SQL and execution time and associates them with the current HTTP request.
+
+### What Gets Captured
+
+Each query entry in the `data.queries` array contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sql` | string | The SQL query with `?` placeholders — parameter values are **not** captured |
+| `time` | number | Execution time in milliseconds |
+
+**Example payload:**
+```json
+{
+  "data": {
+    "queries": [
+      {
+        "sql": "SELECT * FROM \"users\" WHERE \"id\" = ?",
+        "time": 3.42
+      },
+      {
+        "sql": "SELECT COUNT(*) FROM \"orders\" WHERE \"user_id\" = ?",
+        "time": 1.87
+      }
+    ]
+  }
+}
+```
+
 ## Disabling the Exception Handler
 
 By default, Treblle captures and reports exceptions that occur during request processing. If you need to disable this behavior, you can configure it when registering the middleware:

--- a/TreblleCore/Queries/QueryEntry.cs
+++ b/TreblleCore/Queries/QueryEntry.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Treblle.Net.Core;
+
+public sealed class QueryEntry
+{
+    [JsonPropertyName("sql")]
+    public string Sql { get; set; } = string.Empty;
+
+    [JsonPropertyName("time")]
+    public double Time { get; set; }
+}

--- a/TreblleCore/Queries/TreblleDiagnosticHostedService.cs
+++ b/TreblleCore/Queries/TreblleDiagnosticHostedService.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace Treblle.Net.Core;
+
+internal sealed class TreblleDiagnosticHostedService : IHostedService
+{
+    private IDisposable? _subscription;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _subscription = DiagnosticListener.AllListeners.Subscribe(new TreblleDiagnosticObserver());
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _subscription?.Dispose();
+        _subscription = null;
+        return Task.CompletedTask;
+    }
+}

--- a/TreblleCore/Queries/TreblleDiagnosticObserver.cs
+++ b/TreblleCore/Queries/TreblleDiagnosticObserver.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Treblle.Net.Core;
+
+internal sealed class TreblleDiagnosticObserver :
+    IObserver<DiagnosticListener>,
+    IObserver<KeyValuePair<string, object?>>
+{
+    private const string EfCoreSourceName = "Microsoft.EntityFrameworkCore";
+    private const string CommandExecutedEvent = "Microsoft.EntityFrameworkCore.Database.Command.CommandExecuted";
+
+    // Caches (PropertyInfo getter, duration getter, commandText getter) per event data type
+    private static readonly ConcurrentDictionary<Type, (Func<object, object?> GetCommand, Func<object, TimeSpan?> GetDuration, Func<object, string?> GetCommandText)> _accessors = new();
+
+    void IObserver<DiagnosticListener>.OnNext(DiagnosticListener listener)
+    {
+        if (listener.Name == EfCoreSourceName)
+            listener.Subscribe(this);
+    }
+
+    void IObserver<KeyValuePair<string, object?>>.OnNext(KeyValuePair<string, object?> pair)
+    {
+        if (pair.Key != CommandExecutedEvent || pair.Value is null)
+            return;
+
+        try
+        {
+            var accessors = _accessors.GetOrAdd(pair.Value.GetType(), BuildAccessors);
+            var command = accessors.GetCommand(pair.Value);
+            var duration = accessors.GetDuration(pair.Value);
+            var sql = command is not null ? accessors.GetCommandText(command) : null;
+
+            if (sql is not null && duration.HasValue)
+                TreblleQueryCollector.Add(sql, duration.Value.TotalMilliseconds);
+        }
+        catch
+        {
+            // Never fail in a diagnostic observer
+        }
+    }
+
+    private static (Func<object, object?>, Func<object, TimeSpan?>, Func<object, string?>) BuildAccessors(Type eventType)
+    {
+        var commandProp = eventType.GetProperty("Command", BindingFlags.Public | BindingFlags.Instance);
+        var durationProp = eventType.GetProperty("Duration", BindingFlags.Public | BindingFlags.Instance);
+        var commandTextProp = commandProp?.PropertyType.GetProperty("CommandText", BindingFlags.Public | BindingFlags.Instance);
+
+        Func<object, object?> getCommand = commandProp is not null
+            ? o => commandProp.GetValue(o)
+            : _ => null;
+
+        Func<object, TimeSpan?> getDuration = durationProp is not null
+            ? o => durationProp.GetValue(o) is TimeSpan ts ? ts : null
+            : _ => null;
+
+        Func<object, string?> getCommandText = commandTextProp is not null
+            ? o => commandTextProp.GetValue(o) as string
+            : _ => null;
+
+        return (getCommand, getDuration, getCommandText);
+    }
+
+    void IObserver<DiagnosticListener>.OnCompleted() { }
+    void IObserver<DiagnosticListener>.OnError(Exception error) { }
+    void IObserver<KeyValuePair<string, object?>>.OnCompleted() { }
+    void IObserver<KeyValuePair<string, object?>>.OnError(Exception error) { }
+}

--- a/TreblleCore/Queries/TreblleQueryCollector.cs
+++ b/TreblleCore/Queries/TreblleQueryCollector.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Treblle.Net.Core;
+
+internal static class TreblleQueryCollector
+{
+    private static readonly AsyncLocal<List<QueryEntry>?> _queries = new();
+    private const int MaxQueries = 100;
+
+    internal static void Initialize()
+    {
+        _queries.Value = new List<QueryEntry>(16);
+    }
+
+    internal static void Add(string sql, double timeMs)
+    {
+        var list = _queries.Value;
+        if (list is not null && list.Count < MaxQueries)
+        {
+            list.Add(new QueryEntry { Sql = sql, Time = Math.Round(timeMs, 2) });
+        }
+    }
+
+    internal static IReadOnlyList<QueryEntry> GetQueries()
+        => (IReadOnlyList<QueryEntry>?)_queries.Value ?? Array.Empty<QueryEntry>();
+}

--- a/TreblleCore/ServiceCollectionExtensions.cs
+++ b/TreblleCore/ServiceCollectionExtensions.cs
@@ -196,6 +196,8 @@ public static class ServiceCollectionExtensions
         // Register masker factory for .NET 6+ compatibility
         services.TryAddSingleton<MaskerFactory>();
 
+        services.AddHostedService<TreblleDiagnosticHostedService>();
+
         return services;
     }
 
@@ -323,6 +325,8 @@ public static class ServiceCollectionExtensions
 
         // Register masker factory for .NET 6+ compatibility
         services.TryAddSingleton<MaskerFactory>();
+
+        services.AddHostedService<TreblleDiagnosticHostedService>();
 
         return services;
     }

--- a/TreblleCore/Treblle.Net.Core.csproj
+++ b/TreblleCore/Treblle.Net.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Authors>Treblle</Authors>
-    <Version>2.0.12</Version>
+    <Version>2.1.0</Version>
     <PackageId>Treblle.Net.Core</PackageId>
     <Product>Treblle .NET Core</Product>
     <Description>Treblle makes it super easy to understand what's going on with your APIs and the apps that use them.</Description>

--- a/TreblleCore/TreblleJsonContext.cs
+++ b/TreblleCore/TreblleJsonContext.cs
@@ -9,6 +9,8 @@ namespace Treblle.Net.Core;
 /// Provides compile-time serialization code generation for better performance.
 /// </summary>
 [JsonSerializable(typeof(TrebllePayload))]
+[JsonSerializable(typeof(QueryEntry))]
+[JsonSerializable(typeof(List<QueryEntry>))]
 [JsonSerializable(typeof(JsonElement))]
 [JsonSerializable(typeof(object))] // For dynamic request/response bodies
 [JsonSerializable(typeof(List<object>))] 

--- a/TreblleCore/TreblleMiddleware.cs
+++ b/TreblleCore/TreblleMiddleware.cs
@@ -202,6 +202,8 @@ internal class TreblleMiddleware : IDisposable
 
         try
         {
+            TreblleQueryCollector.Initialize();
+
             httpContext.Request.EnableBuffering();
 
             // Check if we should capture response based on expected size

--- a/TreblleCore/TrebllePayload.cs
+++ b/TreblleCore/TrebllePayload.cs
@@ -99,6 +99,8 @@ namespace Treblle.Net.Core
         public Response Response { get; set; } = new();
         [JsonPropertyName("errors")]
         public List<Error> Errors { get; set; } = new();
+        [JsonPropertyName("queries")]
+        public List<QueryEntry> Queries { get; set; } = new();
     }
 
     public class TrebllePayload

--- a/TreblleCore/TrebllePayloadFactory.cs
+++ b/TreblleCore/TrebllePayloadFactory.cs
@@ -74,6 +74,8 @@ internal sealed class TrebllePayloadFactory
 
         TryAddError(exception, payload);
 
+        payload.Data.Queries = TreblleQueryCollector.GetQueries().ToList();
+
         return payload;
     }
 


### PR DESCRIPTION
Treblle .NET Core SDK now automatically captures SQL queries executed during each API request - no configuration required.

Every tracked request will include a `queries` array in the Treblle payload showing the SQL statements that ran and how long each one took