### PR TITLE
fix: capture route template before _next to prevent duplicate endpoints on error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ app.UseTreblle();
 > **💡 Where to place this code:**
 > - **Program.cs** (new minimal hosting model): Add `builder.Services.AddTreblle()` before `builder.Build()` and `app.UseTreblle()` after `var app = builder.Build()`
 > - **Startup.cs** (legacy): Add `services.AddTreblle()` in `ConfigureServices()` and `app.UseTreblle()` in `Configure()`
-> - **Web API templates**: Place after authentication/authorization middleware but before routing
+> - **⚠️ Required:** `app.UseTreblle()` must come **after** `app.UseRouting()`. Placing it before routing means error responses (4xx/5xx) will not be grouped under the correct endpoint on the Treblle dashboard.
 
 **Using .env Files with DotNetEnv**
 
@@ -222,8 +222,8 @@ public class Startup
 
     public void Configure(IApplicationBuilder app)
     {
-        app.UseTreblle();
         app.UseRouting();
+        app.UseTreblle();
         app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
     }
 }
@@ -389,8 +389,6 @@ PAYMENTS_API_KEY=your_payments_project_id
 The environment variable is resolved once at application startup — there is no per-request overhead. If the variable is not set, the request falls back to the globally configured API key.
 
 The attribute is not required for standard tracking — all endpoints are monitored automatically. Use it only when you need to route specific controllers or actions to a different Treblle project.
-
-Note that `app.UseTreblle()` has to come after `app.UseRouting()` for this to work.
 
 ### Excluding endpoints or paths
 

--- a/TreblleCore/Treblle.Net.Core.csproj
+++ b/TreblleCore/Treblle.Net.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Authors>Treblle</Authors>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <PackageId>Treblle.Net.Core</PackageId>
     <Product>Treblle .NET Core</Product>
     <Description>Treblle makes it super easy to understand what's going on with your APIs and the apps that use them.</Description>

--- a/TreblleCore/TreblleMiddleware.cs
+++ b/TreblleCore/TreblleMiddleware.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System;
@@ -200,6 +201,14 @@ internal class TreblleMiddleware : IDisposable
         bool shouldCaptureResponse = true;
         Exception? capturedException = null;
 
+        // Capture route template before _next — UseExceptionHandler (registered after UseTreblle)
+        // calls context.SetEndpoint(null) when handling errors, so GetEndpoint() returns null by the time
+        // the finally block runs.
+        var routeEndpoint = httpContext.GetEndpoint() as RouteEndpoint;
+        var capturedRoutePath = routeEndpoint?.RoutePattern?.RawText is not null
+            ? "/" + routeEndpoint.RoutePattern.RawText
+            : null;
+
         try
         {
             TreblleQueryCollector.Initialize();
@@ -271,7 +280,8 @@ internal class TreblleMiddleware : IDisposable
                         capturedException != null ? null : memoryStream,
                         elapsedMiliseconds,
                         exception: exception,
-                        treblleAttribute: treblleAttribute);
+                        treblleAttribute: treblleAttribute,
+                        capturedRoutePath: capturedRoutePath);
 
                     _channel.Writer.TryWrite(payload);
 

--- a/TreblleCore/TrebllePayloadFactory.cs
+++ b/TreblleCore/TrebllePayloadFactory.cs
@@ -51,7 +51,8 @@ internal sealed class TrebllePayloadFactory
         MemoryStream? response,
         long elapsedMilliseconds,
         Exception? exception = null,
-        TreblleAttribute? treblleAttribute = null)
+        TreblleAttribute? treblleAttribute = null,
+        string? capturedRoutePath = null)
     {
         string? apiKey = treblleAttribute?.ApiKey;
 
@@ -68,7 +69,7 @@ internal sealed class TrebllePayloadFactory
 
         AddServer(httpContext, payload);
 
-        await AddRequest(httpContext, payload);
+        await AddRequest(httpContext, payload, capturedRoutePath);
 
         await TryAddResponse(httpContext, response, elapsedMilliseconds, payload);
 
@@ -114,7 +115,7 @@ internal sealed class TrebllePayloadFactory
         payload.Data.Server.Os.Architecture = CachedArchitecture;
     }
 
-    private async Task AddRequest(HttpContext httpContext, TrebllePayload payload)
+    private async Task AddRequest(HttpContext httpContext, TrebllePayload payload, string? capturedRoutePath = null)
     {
         try
         {
@@ -123,11 +124,22 @@ internal sealed class TrebllePayloadFactory
             payload.Data.Request.Ip = !string.IsNullOrEmpty(serverIpAddress) ? serverIpAddress : "bogon";
             payload.Data.Request.Url = httpContext.Request.GetDisplayUrl();
             payload.Data.Request.Query = httpContext.Request.QueryString.ToString();
-            var routeEndpoint = httpContext.GetEndpoint() as RouteEndpoint;
-            var routeTemplate = routeEndpoint?.RoutePattern?.RawText;
-            payload.Data.Request.RoutePath = routeTemplate is not null
-                ? "/" + routeTemplate
-                : NormalizeRoutePath(httpContext.Request.Path);
+            // Prefer the route template captured before _next. UseExceptionHandler (when registered after
+            // UseTreblle) calls SetEndpoint(null) when handling errors, so GetEndpoint() is unreliable here.
+            // Fall back to GetEndpoint() for apps that register UseTreblle before UseRouting — endpoint is
+            // null before _next in that setup but is resolved by the time we reach this point for 2xx responses.
+            if (capturedRoutePath is not null)
+            {
+                payload.Data.Request.RoutePath = capturedRoutePath;
+            }
+            else
+            {
+                var routeEndpoint = httpContext.GetEndpoint() as RouteEndpoint;
+                var routeTemplate = routeEndpoint?.RoutePattern?.RawText;
+                payload.Data.Request.RoutePath = routeTemplate is not null
+                    ? "/" + routeTemplate
+                    : NormalizeRoutePath(httpContext.Request.Path);
+            }
             payload.Data.Request.UserAgent = httpContext.Request.Headers["User-Agent"].ToString();
             payload.Data.Request.Method = httpContext.Request.Method;
 


### PR DESCRIPTION
## Problem

When `UseExceptionHandler` is registered after `UseTreblle`, it runs inside `_next` and calls `context.SetEndpoint(null)` when handling exceptions. By the time the `finally` block reads the route template via `GetEndpoint()`, the endpoint is already cleared — causing `NormalizeRoutePath` to run as a fallback and produce a different path than the route template (e.g. `{workspaceId}` vs `{id}`), which the ETL treats as a new endpoint. 2xx responses were unaffected since no exception handler runs and `GetEndpoint()` remains intact.

## Fix

Capture the route template before `_next` is called, where the endpoint is guaranteed to be resolved. The original `GetEndpoint()` call is kept as a fallback for apps that register `UseTreblle` before `UseRouting`.

README updated to clarify that `UseTreblle` must come after `UseRouting`.