### PR TITLE
send query params as body for requests without a body

### DIFF
--- a/TreblleCore/Treblle.Net.Core.csproj
+++ b/TreblleCore/Treblle.Net.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Authors>Treblle</Authors>
-    <Version>2.1.1</Version>
+    <Version>2.1.2</Version>
     <PackageId>Treblle.Net.Core</PackageId>
     <Product>Treblle .NET Core</Product>
     <Description>Treblle makes it super easy to understand what's going on with your APIs and the apps that use them.</Description>

--- a/TreblleCore/TrebllePayloadFactory.cs
+++ b/TreblleCore/TrebllePayloadFactory.cs
@@ -307,6 +307,10 @@ internal sealed class TrebllePayloadFactory
                     httpContext.Request.Body.Position = 0;
                 }
             }
+            else if (httpContext.Request.Query.Count > 0)
+            {
+                payload.Data.Request.Body = ParseQueryToDictionary(httpContext.Request.Query);
+            }
         }
         catch (Exception ex)
         {
@@ -315,6 +319,40 @@ internal sealed class TrebllePayloadFactory
                 "An error occurred while attempting to read request body. --- Exception message: {Message}",
                 ex.Message);
         }
+    }
+
+    // Parses IQueryCollection into a nested dictionary, expanding bracket notation.
+    // "filter[time_period]=all&limit=50" → {"filter": {"time_period": "all"}, "limit": "50"}
+    private static Dictionary<string, object> ParseQueryToDictionary(IQueryCollection query)
+    {
+        var result = new Dictionary<string, object>();
+
+        foreach (var param in query)
+        {
+            var key   = param.Key;
+            var value = param.Value.ToString();
+
+            var bracketStart = key.IndexOf('[');
+            if (bracketStart > 0 && key.EndsWith(']'))
+            {
+                var outerKey = key[..bracketStart];
+                var innerKey = key[(bracketStart + 1)..^1];
+
+                if (!result.TryGetValue(outerKey, out var existing) || existing is not Dictionary<string, object> nested)
+                {
+                    nested = new Dictionary<string, object>();
+                    result[outerKey] = nested;
+                }
+
+                ((Dictionary<string, object>)result[outerKey])[innerKey] = value;
+            }
+            else
+            {
+                result[key] = value;
+            }
+        }
+
+        return result;
     }
 
     private async Task TryAddResponse(HttpContext httpContext, MemoryStream? response, long elapsedMilliseconds, TrebllePayload payload)


### PR DESCRIPTION
For GET (and other bodyless) requests, the SDK previously left data.request.body null, so the ETL skipped query param extraction and stored nothing in request_data. Laravel's SDK sends query params as the body for these requests, which is what the ETL expects.

Now, when Content-Type is absent but query params are present, the SDK populates body with a parsed dictionary that expands bracket notation (filter[time_period]=all → {"filter":{"time_period":"all"}}) to match the ETL's parse_str output.