### PR TITLE
fix query params not sent when Content-Type is present on GET requests

### DIFF
--- a/TreblleCore/TrebllePayloadFactory.cs
+++ b/TreblleCore/TrebllePayloadFactory.cs
@@ -307,7 +307,8 @@ internal sealed class TrebllePayloadFactory
                     httpContext.Request.Body.Position = 0;
                 }
             }
-            else if (httpContext.Request.Query.Count > 0)
+
+            if (payload.Data.Request.Body == null && httpContext.Request.Query.Count > 0)
             {
                 payload.Data.Request.Body = ParseQueryToDictionary(httpContext.Request.Query);
             }


### PR DESCRIPTION
Clients that send Content-Type: application/json on GET requests caused the query param fallback to be skipped since it was in an else-if branch. Changed to an unconditional check after the body-reading block so query params are always sent as body when no body was captured.