### PR TITLE
mask authorization and x-api-key header values

### DIFF
--- a/TreblleCore/Masking/AuthorizationMasker.cs
+++ b/TreblleCore/Masking/AuthorizationMasker.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Treblle.Net.Core.Masking;
+
+internal sealed class AuthorizationMasker : IStringMasker
+{
+    private static readonly string[] SchemesWithToken = new[] { "bearer", "basic", "digest" };
+
+    public bool IsPatternMatch(string input) => false;
+
+    public string Mask(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return input;
+
+        var spaceIndex = input.IndexOf(' ');
+        if (spaceIndex > 0)
+        {
+            var scheme = input[..spaceIndex];
+            var token  = input[(spaceIndex + 1)..];
+
+            if (Array.IndexOf(SchemesWithToken, scheme.ToLowerInvariant()) >= 0)
+                return scheme + " " + new string('*', token.Length);
+        }
+
+        return new string('*', input.Length);
+    }
+}

--- a/TreblleCore/Masking/MaskerFactory.cs
+++ b/TreblleCore/Masking/MaskerFactory.cs
@@ -25,7 +25,8 @@ internal class MaskerFactory
             { nameof(CreditCardMasker), typeof(CreditCardMasker) },
             { nameof(SocialSecurityMasker), typeof(SocialSecurityMasker) },
             { nameof(DateMasker), typeof(DateMasker) },
-            { nameof(PostalCodeMasker), typeof(PostalCodeMasker) }
+            { nameof(PostalCodeMasker), typeof(PostalCodeMasker) },
+            { nameof(AuthorizationMasker), typeof(AuthorizationMasker) }
         };
     }
 

--- a/TreblleCore/ServiceCollectionExtensions.cs
+++ b/TreblleCore/ServiceCollectionExtensions.cs
@@ -34,7 +34,9 @@ public static class ServiceCollectionExtensions
         { "user.dob", "DateMasker" },
         { "user.password","DefaultStringMasker" },
         { "user.ss", "SocialSecurityMasker" },
-        { "user.payments.cc", "CreditCardMasker" }
+        { "user.payments.cc", "CreditCardMasker" },
+        { "authorization", "AuthorizationMasker" },
+        { "x-api-key", "AuthorizationMasker" }
     };
    
     /// <summary>
@@ -192,6 +194,7 @@ public static class ServiceCollectionExtensions
         services.TryAddTransient<SocialSecurityMasker>();
         services.TryAddTransient<DateMasker>();
         services.TryAddTransient<PostalCodeMasker>();
+        services.TryAddTransient<AuthorizationMasker>();
 
         // Register masker factory for .NET 6+ compatibility
         services.TryAddSingleton<MaskerFactory>();
@@ -322,6 +325,7 @@ public static class ServiceCollectionExtensions
         services.TryAddTransient<SocialSecurityMasker>();
         services.TryAddTransient<DateMasker>();
         services.TryAddTransient<PostalCodeMasker>();
+        services.TryAddTransient<AuthorizationMasker>();
 
         // Register masker factory for .NET 6+ compatibility
         services.TryAddSingleton<MaskerFactory>();

--- a/TreblleCore/Treblle.Net.Core.csproj
+++ b/TreblleCore/Treblle.Net.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Authors>Treblle</Authors>
-    <Version>2.1.2</Version>
+    <Version>2.1.4</Version>
     <PackageId>Treblle.Net.Core</PackageId>
     <Product>Treblle .NET Core</Product>
     <Description>Treblle makes it super easy to understand what's going on with your APIs and the apps that use them.</Description>


### PR DESCRIPTION
Adds AuthorizationMasker which preserves the auth scheme and masks only the token — Bearer/Basic/Digest values become e.g. "Bearer ***" instead of being either unmasked or fully starred. Registers it for the "authorization" and "x-api-key" fields to match Laravel SDK behaviour.