### PR TITLE
fix: skip response buffering for SSE endpoints

### DIFF
--- a/TreblleCore/Treblle.Net.Core.csproj
+++ b/TreblleCore/Treblle.Net.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Authors>Treblle</Authors>
-    <Version>2.1.4</Version>
+    <Version>2.1.5</Version>
     <PackageId>Treblle.Net.Core</PackageId>
     <Product>Treblle .NET Core</Product>
     <Description>Treblle makes it super easy to understand what's going on with your APIs and the apps that use them.</Description>

--- a/TreblleCore/TreblleMiddleware.cs
+++ b/TreblleCore/TreblleMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
@@ -109,7 +109,7 @@ internal class TreblleMiddleware : IDisposable
                 {
                     _cancellationTokenSource.Cancel();
                     _channel.Writer.Complete();
-                    
+
                     // Wait for background task to complete with timeout
                     if (!_backgroundTask.Wait(TimeSpan.FromSeconds(5)))
                     {
@@ -131,7 +131,7 @@ internal class TreblleMiddleware : IDisposable
                     _cancellationTokenSource.Dispose();
                 }
             }
-            
+
             _disposed = true;
         }
     }
@@ -140,15 +140,15 @@ internal class TreblleMiddleware : IDisposable
     {
         var treblleAttribute = httpContext.GetEndpoint()?.Metadata.GetMetadata<TreblleAttribute>();
         var requestPath = httpContext.Request.Path.Value ?? "/";
-        
+
         // Determine if this endpoint should be tracked
         bool shouldTrack;
-        
+
         if (treblleAttribute is not null)
         {
             // Explicit [Treblle] attribute always enables tracking (unless explicitly excluded)
             shouldTrack = !PathMatcher.ShouldExcludePath(requestPath, _options.ExcludedPaths);
-            
+
             if (_options.DebugMode)
             {
                 var endpoint = httpContext.GetEndpoint();
@@ -167,7 +167,7 @@ internal class TreblleMiddleware : IDisposable
         {
             // Auto-discovery mode: use intelligent filtering for API endpoints
             shouldTrack = ApiRequestFilter.ShouldTrackRequest(httpContext, _options.ExcludedPaths);
-            
+
             if (_options.DebugMode)
             {
                 var endpoint = httpContext.GetEndpoint();
@@ -182,7 +182,7 @@ internal class TreblleMiddleware : IDisposable
                 }
             }
         }
-        
+
         if (shouldTrack)
         {
             await HandleRequestWithTreblleAsync(httpContext, treblleAttribute);
@@ -197,8 +197,7 @@ internal class TreblleMiddleware : IDisposable
     {
         var originalResponseBody = httpContext.Response.Body;
         var stopwatch = Stopwatch.StartNew();
-        MemoryStream? memoryStream = null;
-        bool shouldCaptureResponse = true;
+        ResponseCaptureStream? captureStream = null;
         Exception? capturedException = null;
 
         // Capture route template before _next — UseExceptionHandler (registered after UseTreblle)
@@ -215,31 +214,34 @@ internal class TreblleMiddleware : IDisposable
 
             httpContext.Request.EnableBuffering();
 
-            // Check if we should capture response based on expected size
-            const long maxResponseSize = 5 * 1024 * 1024; // 5MB
-            if (httpContext.Response.ContentLength.HasValue && 
-                httpContext.Response.ContentLength.Value > maxResponseSize)
+            // Skip response capture for responses larger than 5 MB — no point buffering them.
+            const long maxResponseSize = 5 * 1024 * 1024;
+            bool shouldCaptureResponse = !httpContext.Response.ContentLength.HasValue ||
+                                         httpContext.Response.ContentLength.Value <= maxResponseSize;
+
+            if (!shouldCaptureResponse && _options.DebugMode)
             {
-                shouldCaptureResponse = false;
-                if (_options.DebugMode)
-                {
-                    _logger.LogDebug("[TREBLLE]: Skipping response capture for large response: {Size} bytes", 
-                        httpContext.Response.ContentLength.Value);
-                }
+                _logger.LogDebug("[TREBLLE]: Skipping response capture for large response: {Size} bytes",
+                    httpContext.Response.ContentLength!.Value);
             }
 
             if (shouldCaptureResponse)
             {
-                memoryStream = new MemoryStream();
-                httpContext.Response.Body = memoryStream;
+                // ResponseCaptureStream intercepts the first write to check the actual Content-Type.
+                // If it's text/event-stream the stream transparently passes all writes through to the
+                // real response body so SSE chunks reach the client immediately. Otherwise it buffers
+                // into a MemoryStream for Treblle payload construction, identical to previous behavior.
+                captureStream = new ResponseCaptureStream(httpContext, originalResponseBody, _options, _logger);
+                httpContext.Response.Body = captureStream;
             }
 
             await _next(httpContext);
 
-            if (memoryStream != null)
+            var captured = captureStream?.CapturedContent;
+            if (captured != null)
             {
-                memoryStream.Position = 0;
-                await memoryStream.CopyToAsync(originalResponseBody);
+                captured.Position = 0;
+                await captured.CopyToAsync(originalResponseBody);
             }
         }
         catch (Exception ex)
@@ -277,7 +279,7 @@ internal class TreblleMiddleware : IDisposable
                     var payload = await _trebllePayloadFactory.CreateAsync(
                         httpContext,
                         // Response body was not captured when exception bypassed our stream swap
-                        capturedException != null ? null : memoryStream,
+                        capturedException != null ? null : captureStream?.CapturedContent,
                         elapsedMiliseconds,
                         exception: exception,
                         treblleAttribute: treblleAttribute,
@@ -306,8 +308,94 @@ internal class TreblleMiddleware : IDisposable
                 }
             }
 
-            // Dispose memory stream after payload creation
-            memoryStream?.Dispose();
+            captureStream?.Dispose();
         }
+    }
+
+    // Wraps the response body stream. On the first write it checks Response.ContentType:
+    //   - text/event-stream → swaps Response.Body back to the real stream and passes through all writes
+    //   - anything else     → buffers into a MemoryStream so the middleware can read the body for the payload
+    private sealed class ResponseCaptureStream : Stream
+    {
+        private readonly HttpContext _httpContext;
+        private readonly Stream _originalBody;
+        private readonly TreblleOptions _options;
+        private readonly ILogger _logger;
+
+        private MemoryStream? _buffer;
+        private bool _resolved;
+        private bool _passThrough;
+
+        public ResponseCaptureStream(HttpContext httpContext, Stream originalBody, TreblleOptions options, ILogger logger)
+        {
+            _httpContext = httpContext;
+            _originalBody = originalBody;
+            _options = options;
+            _logger = logger;
+        }
+
+        // Returns the buffered content when in buffering mode, null when streaming or when nothing was written.
+        public MemoryStream? CapturedContent => _passThrough ? null : _buffer;
+
+        private Stream Resolve()
+        {
+            if (_resolved)
+                return _passThrough ? _originalBody : _buffer!;
+
+            _resolved = true;
+
+            if (_httpContext.Response.ContentType?.Contains("text/event-stream", StringComparison.OrdinalIgnoreCase) == true)
+            {
+                _passThrough = true;
+                // Restore the real stream so subsequent Response.Body accesses in the controller
+                // loop go directly to the client without touching this wrapper again.
+                _httpContext.Response.Body = _originalBody;
+
+                if (_options.DebugMode)
+                    _logger.LogDebug("[TREBLLE]: Skipping response capture for SSE response");
+
+                return _originalBody;
+            }
+
+            _buffer = new MemoryStream();
+            return _buffer;
+        }
+
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken ct)
+            => await Resolve().WriteAsync(buffer, offset, count, ct);
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ct = default)
+            => await Resolve().WriteAsync(buffer, ct);
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => Resolve().Write(buffer, offset, count);
+
+        public override Task FlushAsync(CancellationToken ct)
+            => _passThrough ? _originalBody.FlushAsync(ct) : (_buffer?.FlushAsync(ct) ?? Task.CompletedTask);
+
+        public override void Flush()
+        {
+            if (_passThrough) _originalBody.Flush();
+            else _buffer?.Flush();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) _buffer?.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
     }
 }


### PR DESCRIPTION
  ## Problem

  The middleware unconditionally swapped `Response.Body` for a `MemoryStream`
  before calling `_next`, then copied the buffer to the real stream after the
  handler completed. For SSE endpoints this meant the entire stream was held
  in memory until the connection closed — clients received nothing until the
  handler finished.

  ## Solution

  Replaced the plain `MemoryStream` with a `ResponseCaptureStream` wrapper.
  On the first write it checks the actual response `Content-Type`:

  - **`text/event-stream`** — passes writes directly to the client
  - **Anything else** — buffers into a `MemoryStream` as before

  No attributes or configuration required. Works because `Content-Type` is
  always set before the first write, so the content type is known at the
  moment it's needed.